### PR TITLE
Adds abi parameter so it can be used with proxy, or unverified contracts

### DIFF
--- a/apps/next/pages/v0/decode.tsx
+++ b/apps/next/pages/v0/decode.tsx
@@ -166,9 +166,7 @@ const Decode: NextPage = () => {
         <p className={styles.description}>
           The person who sent you here wants you to call
           <br />
-          <code>`{fn}`</code> on <code>`{contractAddress}`</code> with params
-          <br />
-          <code>`{fnParamsStr}`</code>
+          <code>`{fn}`</code> on <code>`{contractAddress}`</code>
         </p>
         <Button
           onClick={executeTxn ? executeTxn : () => {}}

--- a/apps/next/pages/v0/decode.tsx
+++ b/apps/next/pages/v0/decode.tsx
@@ -29,6 +29,7 @@ interface RouterQuery {
   chainID: string | undefined;
   fn: string | undefined;
   fnParams: string | undefined;
+  abi: string | undefined;
   to: string | undefined;
   value: string | undefined;
 }
@@ -37,9 +38,14 @@ const Decode: NextPage = () => {
   const routerQuery = router.query as unknown as RouterQuery;
   const [contractAddress, setContractAddress] = useState<`0x${string}`>();
   const [fn, setFn] = useState<string>();
+  const [fnParamsStr, setFnParamsStr] = useState<string>();
   const [contractABI, setContractABI] = useState<Abi>();
   const { data: walletClient } = useWalletClient();
   const { chainId } = useAccount();
+
+  const functionParams = EncodeURIComponent.decode(
+    routerQuery.fnParams as string,
+  );
 
   const { writeContract } = useWriteContract();
   let executeTxn: (() => unknown) | null = null;
@@ -53,18 +59,27 @@ const Decode: NextPage = () => {
     const chainID = parse(string(), routerQuery.chainID);
     setFn(_fn);
     setContractAddress(_contractAddress);
-    // fetch ABI from etherscan
-    fetch(
-      `/api/v0/fetch-abi?contractAddress=${_contractAddress}&chainID=${chainID}`,
-    )
-      .then((res) => res.json())
-      .then((data) => data.abi)
-      .then((abi) => setContractABI(abi))
-      .catch((err) => {
-        toast.warn(
-          `There was an error fetching the ABI. Maybe this contract lives on a different network from network ID ${chainID}?`,
-        );
-      });
+
+    setFnParamsStr(functionParams.toString());
+    // fetch ABI from etherscan if its not provided
+    // One the leaf of the ABI for the fn needs be provided
+    // It should be abi=encodeURIComponent(JSON.stringify(abi))
+    if (routerQuery.abi) {
+      setContractABI(JSON.parse(routerQuery.abi.toString()));
+    } else {
+      fetch(
+        `/api/v0/fetch-abi?contractAddress=${_contractAddress}&chainID=${chainID}`,
+      )
+        .then((res) => res.json())
+        .then((data) => data.abi)
+        .then((abi) => setContractABI(abi))
+        .catch((err) => {
+          toast.warn(
+            `There was an error fetching the ABI. Maybe this contract lives on a different network from network ID ${chainID}?`,
+          );
+          console.error(err);
+        });
+    }
   }, [routerQuery?.fn, router.isReady]);
   // this should only run once
   useEffect(() => {
@@ -132,10 +147,6 @@ const Decode: NextPage = () => {
       return <>Fetching contract ABI...</>;
     }
 
-    const functionParams = EncodeURIComponent.decode(
-      routerQuery.fnParams as string,
-    );
-
     executeTxn = () =>
       writeContract({
         address: contractAddress,
@@ -155,7 +166,9 @@ const Decode: NextPage = () => {
         <p className={styles.description}>
           The person who sent you here wants you to call
           <br />
-          <code>`{fn}`</code> on <code>`{contractAddress}`</code>
+          <code>`{fn}`</code> on <code>`{contractAddress}`</code> with params
+          <br />
+          <code>`{fnParamsStr}`</code>
         </p>
         <Button
           onClick={executeTxn ? executeTxn : () => {}}


### PR DESCRIPTION
Adds `abi` parameter which means the `decode` page can be used programmatically and an abi can be provided for contracts that are proxies or are not verified. 

Does not update the encode page.

Adds small UI change to display decoded call params.

When setting the query parameter it should be `abi=encodeURIComponent(JSON.stringify(abi))`

Closes #15 