### PR TITLE
Add API v1: standardized, wallet-shaped URL format (#26)

### DIFF
--- a/apps/next/pages/index.tsx
+++ b/apps/next/pages/index.tsx
@@ -16,7 +16,7 @@ const Home: NextPage = () => {
         <Image src={dynamiteSrc} width={120} height={120} alt="dynamite" />
 
         <div className={styles.grid}>
-          <Link href="/v0/encode" className={styles.card}>
+          <Link href="/v1/encode" className={styles.card}>
             <h2>
               <Image
                 src="/images/calculator.png"
@@ -33,7 +33,7 @@ const Home: NextPage = () => {
         <h2 className={styles.h2}>Examples</h2>
         <div className={styles.grid}>
           <a
-            href="/v0/decode?chainID=1&contractAddress=0xbe1a33519f586a4c8aa37525163df8d67997016f&fn=claim&fnParams=0%3D6%2C1%3D0x0018Bfd060CB966AbAfE852eb1648a3e4385b477%2C2%3D0x15ac34f35c8a8a4000%2C3%5B0%5D%3D0xdcbe9395349958f3e62500d98a3a4e9c6746c62cb9fd33d3e5e541aa4218acd1%2C3%5B1%5D%3D0x0dfedf53747027eebb3cbe5332bcf5c4bc16d02263244f9cdd99d7ada04432f0%2C3%5B2%5D%3D0x264be6a6457432e8a9894d7ed72bae6450b78f1ddb25b92901e9e758ec590c43%2C3%5B3%5D%3D0x3d2c228a47f63fda1532ea1eb1efa1099db58c89bd3b4d4745707b37cdd99795%2C3%5B4%5D%3D0xc2b6183614f72d5b85c7d53f250db5879560d90f554c65f0fd7d3f6380119fc4%2C3%5B5%5D%3D0xe76ae0d30fa261e7467721193055eb1332c12782cb60d5c8b5698faf596575d0%2C3%5B6%5D%3D0xed9357ca61a04981613541be6a5ee8cc63f35474ecc93eaa957ed2430bf75a8f%2C3%5B7%5D%3D0x23ee7245c67a5bc908c31d3f9be7752ac3490b5ddd3b50553064489e23218ee9%2C3%5B8%5D%3D0xe56ca04bc13b6f40c97dd1d01b2b2b13cec066b5815d5009c0f376906376cdbe%2C3%5B9%5D%3D0xbb82590a09313c61ea7febcfca233db9743a8b768bee8e0ef6b3b3490ffd6bc1%2C3%5B10%5D%3D0x11c2e4ca0ef6bec317ce1835ce64895a4351a26efad65fd263682927056297de%2C3%5B11%5D%3D0x78cb0d3b6c7d126a579b634cc8330a23d10b1d1135f2515154a5582071b3fe8e%2C3%5B12%5D%3D0x52ece03a32eb1cd7bfb1214dc4e5385e5e34366fc98d48dfb3c0a21c40032b96%2C3%5B13%5D%3D0xad6d25188df580042879fdf0ee94033f601bb48dc5e001aabda9df15956bb0bd%2C3%5B14%5D%3D0x6e4d811f548750e6321070ff0f3529d106f7efacf77fb23218253119351d56a0"
+            href="/v1/decode?chainId=1&to=0xbe1a33519f586a4c8aa37525163df8d67997016f&fnSignature=claim%28uint256%2Caddress%2Cuint256%2Cbytes32%5B%5D%29&fnArgs=%5B%226%22%2C%220x0018Bfd060CB966AbAfE852eb1648a3e4385b477%22%2C%220x15ac34f35c8a8a4000%22%2C%5B%220xdcbe9395349958f3e62500d98a3a4e9c6746c62cb9fd33d3e5e541aa4218acd1%22%2C%220x0dfedf53747027eebb3cbe5332bcf5c4bc16d02263244f9cdd99d7ada04432f0%22%2C%220x264be6a6457432e8a9894d7ed72bae6450b78f1ddb25b92901e9e758ec590c43%22%2C%220x3d2c228a47f63fda1532ea1eb1efa1099db58c89bd3b4d4745707b37cdd99795%22%2C%220xc2b6183614f72d5b85c7d53f250db5879560d90f554c65f0fd7d3f6380119fc4%22%2C%220xe76ae0d30fa261e7467721193055eb1332c12782cb60d5c8b5698faf596575d0%22%2C%220xed9357ca61a04981613541be6a5ee8cc63f35474ecc93eaa957ed2430bf75a8f%22%2C%220x23ee7245c67a5bc908c31d3f9be7752ac3490b5ddd3b50553064489e23218ee9%22%2C%220xe56ca04bc13b6f40c97dd1d01b2b2b13cec066b5815d5009c0f376906376cdbe%22%2C%220xbb82590a09313c61ea7febcfca233db9743a8b768bee8e0ef6b3b3490ffd6bc1%22%2C%220x11c2e4ca0ef6bec317ce1835ce64895a4351a26efad65fd263682927056297de%22%2C%220x78cb0d3b6c7d126a579b634cc8330a23d10b1d1135f2515154a5582071b3fe8e%22%2C%220x52ece03a32eb1cd7bfb1214dc4e5385e5e34366fc98d48dfb3c0a21c40032b96%22%2C%220xad6d25188df580042879fdf0ee94033f601bb48dc5e001aabda9df15956bb0bd%22%2C%220x6e4d811f548750e6321070ff0f3529d106f7efacf77fb23218253119351d56a0%22%5D%5D"
             className={styles.card}
             target="_blank"
             rel="noreferrer"
@@ -53,7 +53,7 @@ const Home: NextPage = () => {
             </p>
           </a>
           <a
-            href="/v0/decode?fnParams=0%3D0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB%2C1%3D100&contractAddress=0x6b175474e89094c44da98b954eedeac495271d0f&fn=approve&chainID=1"
+            href="/v1/decode?chainId=1&to=0x6b175474e89094c44da98b954eedeac495271d0f&fnSignature=approve%28address%2Cuint256%29&fnArgs=%5B%220xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB%22%2C%22100%22%5D"
             className={styles.card}
             target="_blank"
             rel="noreferrer"
@@ -70,7 +70,7 @@ const Home: NextPage = () => {
             <p>The First step to any ERC-20 send.</p>
           </a>
           <a
-            href="/v0/decode/?chainID=1&contractAddress=0x6b175474e89094c44da98b954eedeac495271d0f&fn=transfer&fnParams=0=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB,1=100"
+            href="/v1/decode?chainId=1&to=0x6b175474e89094c44da98b954eedeac495271d0f&fnSignature=transfer%28address%2Cuint256%29&fnArgs=%5B%220xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB%22%2C%22100%22%5D"
             className={styles.card}
             target="_blank"
             rel="noreferrer"

--- a/apps/next/pages/v1/decode.tsx
+++ b/apps/next/pages/v1/decode.tsx
@@ -1,0 +1,189 @@
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import type { NextPage } from 'next';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import styled from 'styled-components';
+import { formatEther } from 'viem';
+import { useAccount, useWalletClient } from 'wagmi';
+import {
+  type ParsedTransaction,
+  parseRouterQuery,
+} from '../../../../packages/txn-dot-xyz/utils/v1/v1';
+import { Button } from '../../src/frontend/components/Button';
+import styles from '../../styles/Home.module.css';
+
+// API v1 — the whole transaction is described in the URL query string.
+// Examples:
+//   /v1/decode?chainId=1&to=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB&value=1000000000000000000
+//   /v1/decode?chainId=1&to=0x6b175474e89094c44da98b954eedeac495271d0f&fnSignature=transfer(address,uint256)&fnArgs=["0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB","100"]
+
+const Body = styled.div`
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+`;
+
+const Decode: NextPage = () => {
+  const router = useRouter();
+  const { data: walletClient } = useWalletClient();
+  const { chainId } = useAccount();
+
+  const [txn, setTxn] = useState<ParsedTransaction>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    try {
+      setTxn(parseRouterQuery(router.query));
+      setError(undefined);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Invalid transaction URL');
+    }
+  }, [router.isReady, router.query]);
+
+  // switch the wallet to the requested network
+  useEffect(() => {
+    if (!walletClient || !txn) {
+      return;
+    }
+    if (chainId !== txn.chainId) {
+      walletClient.switchChain({ id: txn.chainId }).catch(() => {
+        toast.warn(`Please switch your wallet to chain ${txn.chainId}`);
+      });
+    }
+  }, [chainId, txn, walletClient]);
+
+  if (!router.isReady || (!txn && !error)) {
+    return <Body>loading...</Body>;
+  }
+  if (error) {
+    return (
+      <Body>
+        <p style={{ color: 'red' }}>Could not read transaction: {error}</p>
+      </Body>
+    );
+  }
+  if (!txn) {
+    return <Body>loading...</Body>;
+  }
+  if (!walletClient) {
+    return (
+      <Body>
+        <ConnectButton label="Login to Continue" />
+      </Body>
+    );
+  }
+  if (chainId !== txn.chainId) {
+    return (
+      <Body>
+        <p>
+          Must change network to {txn.chainId}. You&apos;re connected with{' '}
+          {chainId || 'unknown'}
+        </p>
+        <ConnectButton />
+      </Body>
+    );
+  }
+
+  const executeTxn = async () => {
+    const [account] = await walletClient.getAddresses();
+    await walletClient.sendTransaction({
+      account,
+      to: txn.to,
+      value: txn.value,
+      data: txn.data,
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <main className={styles.main}>
+        <ConnectButton />
+
+        <h1 className={styles.title}>txn.xyz</h1>
+
+        <Description txn={txn} />
+
+        <Button
+          onClick={executeTxn}
+          style={{ fontSize: '20px', marginTop: '24px' }}
+        >
+          Execute Transaction
+        </Button>
+
+        <div className={styles.grid} style={{ marginTop: '100px' }}>
+          <Link href="/" className={styles.card}>
+            <h2>What is this?&rarr;</h2>
+            <p>
+              txn.xyz is a new way to use Ethereum. Everything required to send
+              a transaction is URL encoded!
+            </p>
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+const Description: React.FunctionComponent<{ txn: ParsedTransaction }> = ({
+  txn,
+}) => {
+  // contract function call
+  if (txn.functionName) {
+    return (
+      <div className={styles.description} style={{ textAlign: 'center' }}>
+        <p>
+          The person who sent you here wants you to call{' '}
+          <code>`{txn.functionName}`</code> on <code>`{txn.to}`</code>
+        </p>
+        {txn.args && txn.args.length > 0 && (
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {txn.args.map((arg, i) => (
+              <li key={i}>
+                <code>{JSON.stringify(arg)}</code>
+              </li>
+            ))}
+          </ul>
+        )}
+        {txn.value > 0n && (
+          <p>Including {formatEther(txn.value)} in native token</p>
+        )}
+      </div>
+    );
+  }
+
+  // arbitrary pre-encoded data
+  if (txn.data && txn.data !== '0x') {
+    return (
+      <div className={styles.description} style={{ textAlign: 'center' }}>
+        <p>
+          The person who sent you here wants you to send a transaction to{' '}
+          <code>`{txn.to}`</code> with custom data.
+        </p>
+        <p style={{ color: 'orange' }}>
+          ⚠️ Review carefully. Arbitrary transaction data could be malicious.
+        </p>
+        <code style={{ wordBreak: 'break-all' }}>{txn.data}</code>
+      </div>
+    );
+  }
+
+  // bare native-token transfer
+  return (
+    <div className={styles.description} style={{ textAlign: 'center' }}>
+      <p>
+        The person who sent you here wants you to send{' '}
+        <b>{formatEther(txn.value)}</b> in native token to{' '}
+        <code>`{txn.to}`</code>
+      </p>
+    </div>
+  );
+};
+
+export default Decode;

--- a/apps/next/pages/v1/encode.tsx
+++ b/apps/next/pages/v1/encode.tsx
@@ -1,0 +1,126 @@
+import type { NextPage } from 'next';
+import { useMemo, useState } from 'react';
+import Select from 'react-select';
+import { toast } from 'react-toastify';
+import { buildV1Url } from '../../../../packages/txn-dot-xyz/utils/v1/v1';
+import { Button } from '../../src/frontend/components/Button';
+import { Input } from '../../src/frontend/components/Input';
+import styles from '../../styles/Home.module.css';
+
+const chainOptions = [
+  { value: 1, label: 'Ethereum' },
+  { value: 137, label: 'Polygon' },
+  { value: 10, label: 'Optimism' },
+  { value: 42161, label: 'Arbitrum One' },
+  { value: 100, label: 'Gnosis Chain' },
+  { value: 56, label: 'Binance Smart Chain' },
+  { value: 8453, label: 'Base' },
+];
+
+// Parse the comma-separated (or JSON) argument input into an array.
+// Use a JSON array (e.g. ["0xabc", ["0x1","0x2"]]) for nested arguments.
+function parseArgsInput(raw: string): unknown[] {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return [];
+  }
+  if (trimmed.startsWith('[')) {
+    return JSON.parse(trimmed);
+  }
+  return trimmed.split(',').map((arg) => arg.trim());
+}
+
+const Encode: NextPage = () => {
+  const [chainId, setChainId] = useState(1);
+  const [to, setTo] = useState('');
+  const [value, setValue] = useState('');
+  const [fnSignature, setFnSignature] = useState('');
+  const [fnArgs, setFnArgs] = useState('');
+
+  const encodedUrl = useMemo(() => {
+    if (!to) {
+      return '';
+    }
+    try {
+      const path = buildV1Url({
+        chainId,
+        to,
+        value: value || undefined,
+        fnSignature: fnSignature || undefined,
+        fnArgs: fnSignature ? parseArgsInput(fnArgs) : undefined,
+      });
+      return `https://txn.xyz${path}`;
+    } catch {
+      return '';
+    }
+  }, [chainId, to, value, fnSignature, fnArgs]);
+
+  const copy = () => {
+    navigator.clipboard.writeText(encodedUrl);
+    toast.success('Copied URL to clipboard');
+  };
+
+  return (
+    <div className={styles.container}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>Encode a Transaction</h1>
+        <p className={styles.description}>
+          Build a txn.xyz API v1 link. Share it and the recipient signs with
+          their own wallet.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <label>Network</label>
+          <div style={{ minWidth: 360 }}>
+            <Select
+              options={chainOptions}
+              value={chainOptions.find((c) => c.value === chainId)}
+              onChange={(option) => option && setChainId(option.value)}
+            />
+          </div>
+
+          <label>Recipient address (to)</label>
+          <Input
+            value={to}
+            placeholder="0x..."
+            onChange={(e) => setTo(e.target.value)}
+          />
+
+          <label>Value in wei (optional)</label>
+          <Input
+            value={value}
+            placeholder="0"
+            onChange={(e) => setValue(e.target.value)}
+          />
+
+          <label>Function signature (optional)</label>
+          <Input
+            value={fnSignature}
+            placeholder="transfer(address,uint256)"
+            onChange={(e) => setFnSignature(e.target.value)}
+          />
+
+          <label>Arguments (comma-separated, or JSON array)</label>
+          <Input
+            value={fnArgs}
+            placeholder="0xRecipient, 100"
+            onChange={(e) => setFnArgs(e.target.value)}
+          />
+        </div>
+
+        {encodedUrl && (
+          <div style={{ marginTop: '24px', textAlign: 'center' }}>
+            <p style={{ wordBreak: 'break-all', maxWidth: 600 }}>
+              <a href={encodedUrl} target="_blank" rel="noreferrer">
+                {encodedUrl}
+              </a>
+            </p>
+            <Button onClick={copy}>Copy URL</Button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default Encode;

--- a/apps/next/tsconfig.json
+++ b/apps/next/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/txn-dot-xyz/package-lock.json
+++ b/packages/txn-dot-xyz/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "qs": "^6.12.1"
+        "qs": "^6.12.1",
+        "viem": "^2.52.2"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -17,6 +18,12 @@
         "jest": "^29.7.0",
         "ts-jest": "^29.1.4"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -974,6 +981,81 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1114,6 +1196,27 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1699,6 +1802,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2092,6 +2201,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -2985,6 +3109,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3592,20 +3746,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
@@ -3648,6 +3788,36 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/walker": {
@@ -3710,6 +3880,27 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3766,6 +3957,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -4498,6 +4694,48 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="
+    },
+    "@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "requires": {
+        "@noble/hashes": "1.8.0"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
+    "@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="
+    },
+    "@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "requires": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "requires": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4638,6 +4876,11 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
+    },
+    "abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -4960,8 +5203,7 @@
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
       "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deepmerge": {
       "version": "4.3.1",
@@ -5048,6 +5290,11 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "execa": {
       "version": "5.1.1",
@@ -5328,6 +5575,11 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -5607,8 +5859,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -6012,6 +6263,21 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
+      }
+    },
+    "ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "requires": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
       }
     },
     "p-limit": {
@@ -6424,13 +6690,6 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
     },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "peer": true
-    },
     "update-browserslist-db": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
@@ -6450,6 +6709,21 @@
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
         "convert-source-map": "^2.0.0"
+      }
+    },
+    "viem": {
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "requires": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       }
     },
     "walker": {
@@ -6496,6 +6770,11 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
+    },
+    "ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/packages/txn-dot-xyz/package.json
+++ b/packages/txn-dot-xyz/package.json
@@ -10,7 +10,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "qs": "^6.12.1"
+    "qs": "^6.12.1",
+    "viem": "^2.52.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/packages/txn-dot-xyz/tsconfig.json
+++ b/packages/txn-dot-xyz/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/txn-dot-xyz/utils/url-encoding/type-casting.test.ts
+++ b/packages/txn-dot-xyz/utils/url-encoding/type-casting.test.ts
@@ -1,0 +1,34 @@
+import { parseValue } from './type-casting';
+
+// These lock in the v0 type-casting behavior so the v1 work cannot
+// silently change how existing v0 URLs are decoded.
+describe('parseValue (v0 type-casting)', () => {
+  it('treats undefined and empty string as null', () => {
+    expect(parseValue(undefined)).toBeNull();
+    expect(parseValue('')).toBeNull();
+  });
+
+  it('parses boolean strings into booleans', () => {
+    expect(parseValue('true')).toBe(true);
+    expect(parseValue('false')).toBe(false);
+  });
+
+  it('parses decimal number strings into numbers', () => {
+    expect(parseValue('100')).toBe(100);
+    expect(parseValue('0')).toBe(0);
+  });
+
+  it('leaves hex strings untouched', () => {
+    expect(parseValue('0x1')).toBe('0x1');
+    expect(parseValue('0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB')).toBe(
+      '0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB',
+    );
+  });
+
+  it('recurses into nested arrays', () => {
+    expect(parseValue(['1', ['0x2', 'true']])).toStrictEqual([
+      1,
+      ['0x2', true],
+    ]);
+  });
+});

--- a/packages/txn-dot-xyz/utils/url-encoding/v0-decode.test.ts
+++ b/packages/txn-dot-xyz/utils/url-encoding/v0-decode.test.ts
@@ -1,0 +1,37 @@
+import { EncodeURIComponent } from './url-encoding';
+
+// Characterizes the exact decoding of the live v0 example URLs (see
+// apps/next/pages/index.tsx). Next.js url-decodes query params before they
+// reach the page, so these are the already-url-decoded `fnParams` strings.
+// If v1 work ever changes EncodeURIComponent, these break loudly.
+describe('v0 example URL decoding', () => {
+  it('decodes the "Transfer DAI" fnParams to [recipient, amount]', () => {
+    const fnParams = '0=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB,1=100';
+    expect(EncodeURIComponent.decode(fnParams)).toStrictEqual([
+      '0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB',
+      100,
+    ]);
+  });
+
+  it('decodes the "Approve DAI" fnParams to [spender, amount]', () => {
+    const fnParams = '0=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB,1=100';
+    expect(EncodeURIComponent.decode(fnParams)).toStrictEqual([
+      '0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB',
+      100,
+    ]);
+  });
+
+  it('round-trips the airdrop claim fnParams (index, address, amount, proof)', () => {
+    const params = [
+      6,
+      '0x0018Bfd060CB966AbAfE852eb1648a3e4385b477',
+      '0x15ac34f35c8a8a4000',
+      [
+        '0xdcbe9395349958f3e62500d98a3a4e9c6746c62cb9fd33d3e5e541aa4218acd1',
+        '0x0dfedf53747027eebb3cbe5332bcf5c4bc16d02263244f9cdd99d7ada04432f0',
+      ],
+    ];
+    const encoded = EncodeURIComponent.encode(params);
+    expect(EncodeURIComponent.decode(encoded)).toStrictEqual(params);
+  });
+});

--- a/packages/txn-dot-xyz/utils/v1/v1.test.ts
+++ b/packages/txn-dot-xyz/utils/v1/v1.test.ts
@@ -1,0 +1,217 @@
+import { encodeFunctionData } from 'viem';
+import {
+  buildV1Url,
+  encodeCalldata,
+  parseChainId,
+  parseRouterQuery,
+  parseTransaction,
+  parseTxValue,
+} from './v1';
+
+describe('parseChainId', () => {
+  it('parses decimal chain id strings', () => {
+    expect(parseChainId('1')).toBe(1);
+    expect(parseChainId('8453')).toBe(8453);
+  });
+  it('parses hex chain id strings (eth_chainId style)', () => {
+    expect(parseChainId('0x1')).toBe(1);
+    expect(parseChainId('0x2105')).toBe(8453);
+  });
+  it('throws on a missing or invalid chain id', () => {
+    expect(() => parseChainId(undefined as unknown as string)).toThrow();
+    expect(() => parseChainId('not-a-number')).toThrow();
+  });
+});
+
+describe('parseTxValue', () => {
+  it('defaults to 0n when undefined', () => {
+    expect(parseTxValue(undefined)).toBe(0n);
+  });
+  it('parses decimal strings as wei', () => {
+    expect(parseTxValue('1000000000000000000')).toBe(1000000000000000000n);
+  });
+  it('parses hex strings as wei', () => {
+    expect(parseTxValue('0xde0b6b3a7640000')).toBe(1000000000000000000n);
+  });
+  it('preserves precision beyond Number.MAX_SAFE_INTEGER', () => {
+    expect(parseTxValue('1234567890123456789012')).toBe(
+      1234567890123456789012n,
+    );
+  });
+});
+
+describe('encodeCalldata', () => {
+  const transferAbi = [
+    {
+      type: 'function',
+      name: 'transfer',
+      stateMutability: 'nonpayable',
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'amount', type: 'uint256' },
+      ],
+      outputs: [],
+    },
+  ] as const;
+
+  it('encodes a function call from a signature + string args', () => {
+    const oracle = encodeFunctionData({
+      abi: transferAbi,
+      functionName: 'transfer',
+      args: [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        1000000000000000000n,
+      ],
+    });
+    expect(
+      encodeCalldata('transfer(address,uint256)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        '1000000000000000000',
+      ]),
+    ).toBe(oracle);
+  });
+
+  it('coerces large uint args without losing precision', () => {
+    const big = '1234567890123456789012345';
+    const oracle = encodeFunctionData({
+      abi: transferAbi,
+      functionName: 'transfer',
+      args: ['0x70997970C51812dc3A010C7d01b50e0d17dc79C8', BigInt(big)],
+    });
+    expect(
+      encodeCalldata('transfer(address,uint256)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        big,
+      ]),
+    ).toBe(oracle);
+  });
+
+  it('supports named parameters in the signature', () => {
+    expect(
+      encodeCalldata('transfer(address to, uint256 amount)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        '100',
+      ]),
+    ).toBe(
+      encodeCalldata('transfer(address,uint256)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        '100',
+      ]),
+    );
+  });
+
+  it('coerces bool args', () => {
+    const approveForAll = encodeCalldata('setApprovalForAll(address,bool)', [
+      '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      'true',
+    ]);
+    expect(approveForAll.startsWith('0x')).toBe(true);
+  });
+
+  it('rejects a bare function name (ambiguous without param types)', () => {
+    expect(() => encodeCalldata('transfer', [])).toThrow();
+  });
+
+  it('throws when arg count does not match the signature', () => {
+    expect(() =>
+      encodeCalldata('transfer(address,uint256)', ['0xabc']),
+    ).toThrow();
+  });
+});
+
+describe('parseTransaction', () => {
+  const to = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+  it('builds a bare value transfer when data is omitted', () => {
+    const txn = parseTransaction({ chainId: '1', to, value: '1000' });
+    expect(txn).toMatchObject({
+      chainId: 1,
+      to,
+      value: 1000n,
+      data: '0x',
+    });
+  });
+
+  it('defaults value to 0n', () => {
+    expect(parseTransaction({ chainId: '1', to }).value).toBe(0n);
+  });
+
+  it('forwards a pre-encoded data string as-is', () => {
+    const txn = parseTransaction({ chainId: '1', to, data: '0xdeadbeef' });
+    expect(txn.data).toBe('0xdeadbeef');
+  });
+
+  it('encodes calldata from fnSignature + fnArgs', () => {
+    const txn = parseTransaction({
+      chainId: '1',
+      to,
+      fnSignature: 'transfer(address,uint256)',
+      fnArgs: ['0x70997970C51812dc3A010C7d01b50e0d17dc79C8', '100'],
+    });
+    expect(txn.data).toBe(
+      encodeCalldata('transfer(address,uint256)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        '100',
+      ]),
+    );
+    expect(txn.functionName).toBe('transfer');
+  });
+
+  it('throws on an invalid recipient address', () => {
+    expect(() => parseTransaction({ chainId: '1', to: 'nope' })).toThrow();
+  });
+});
+
+describe('buildV1Url + parseRouterQuery round-trip', () => {
+  const to = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+  it('round-trips a contract function call through the query string', () => {
+    const url = buildV1Url({
+      chainId: 1,
+      to,
+      fnSignature: 'transfer(address,uint256)',
+      fnArgs: ['0x70997970C51812dc3A010C7d01b50e0d17dc79C8', '100'],
+    });
+    const query = Object.fromEntries(new URLSearchParams(url.split('?')[1]));
+    const txn = parseRouterQuery(query);
+    expect(txn).toMatchObject({
+      chainId: 1,
+      to,
+      value: 0n,
+      functionName: 'transfer',
+    });
+    expect(txn.data).toBe(
+      encodeCalldata('transfer(address,uint256)', [
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        '100',
+      ]),
+    );
+  });
+
+  it('parses a merkle claim with a nested bytes32[] proof', () => {
+    const query = {
+      chainId: '1',
+      to: '0xbe1a33519f586a4c8aa37525163df8d67997016f',
+      fnSignature: 'claim(uint256,address,uint256,bytes32[])',
+      fnArgs: JSON.stringify([
+        '6',
+        '0x0018Bfd060CB966AbAfE852eb1648a3e4385b477',
+        '0x15ac34f35c8a8a4000',
+        [
+          '0xdcbe9395349958f3e62500d98a3a4e9c6746c62cb9fd33d3e5e541aa4218acd1',
+          '0x0dfedf53747027eebb3cbe5332bcf5c4bc16d02263244f9cdd99d7ada04432f0',
+        ],
+      ]),
+    };
+    const txn = parseRouterQuery(query);
+    expect(txn.functionName).toBe('claim');
+    expect(txn.data.startsWith('0x')).toBe(true);
+  });
+
+  it('round-trips a native value transfer', () => {
+    const url = buildV1Url({ chainId: 8453, to, value: '5' });
+    const query = Object.fromEntries(new URLSearchParams(url.split('?')[1]));
+    const txn = parseRouterQuery(query);
+    expect(txn).toMatchObject({ chainId: 8453, to, value: 5n, data: '0x' });
+  });
+});

--- a/packages/txn-dot-xyz/utils/v1/v1.ts
+++ b/packages/txn-dot-xyz/utils/v1/v1.ts
@@ -1,0 +1,211 @@
+import {
+  type Abi,
+  type Address,
+  type Hex,
+  encodeFunctionData,
+  isAddress,
+  parseAbiItem,
+} from 'viem';
+
+/**
+ * txn.xyz API v1.
+ *
+ * A standardized, wallet-shaped transaction description that is encoded
+ * entirely in the URL query string. See issue #26.
+ *
+ *   chainId     ID of the chain (hex like `0x1` or decimal like `1`)
+ *   to          Recipient address (no EOA vs. contract distinction)
+ *   value       Native token amount in wei (optional, defaults to 0)
+ *   data        Either a pre-encoded hex string, or omitted and supplied
+ *               via `fnSignature` + `fnArgs`
+ *   fnSignature Full function signature, e.g. `transfer(address,uint256)`
+ *   fnArgs      JSON-encoded array of arguments
+ */
+
+export type V1Query = {
+  chainId: string;
+  to: string;
+  value?: string;
+  data?: string;
+  fnSignature?: string;
+  fnArgs?: readonly unknown[];
+};
+
+export type ParsedTransaction = {
+  chainId: number;
+  to: Address;
+  value: bigint;
+  data: Hex;
+  /** present only when the transaction is a contract function call */
+  functionName?: string;
+  args?: readonly unknown[];
+};
+
+/** Parse a chain id from the URL. Accepts hex (`0x1`) or decimal (`1`). */
+export function parseChainId(raw: string): number {
+  if (raw === undefined || raw === null || raw === '') {
+    throw new Error('Missing chainId');
+  }
+  const parsed =
+    typeof raw === 'string' && raw.startsWith('0x')
+      ? parseInt(raw, 16)
+      : Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid chainId: ${raw}`);
+  }
+  return parsed;
+}
+
+/** Parse a native-token value into wei. Defaults to 0n. */
+export function parseTxValue(raw?: string): bigint {
+  if (raw === undefined || raw === '') {
+    return 0n;
+  }
+  return BigInt(raw);
+}
+
+/** Coerce a single URL-sourced argument into the JS type viem expects. */
+function coerceArg(type: string, value: unknown): unknown {
+  const arrayMatch = type.match(/^(.*)\[\d*\]$/);
+  if (arrayMatch) {
+    if (!Array.isArray(value)) {
+      throw new Error(`Expected an array for type ${type}`);
+    }
+    return value.map((item) => coerceArg(arrayMatch[1], item));
+  }
+  if (/^u?int\d*$/.test(type)) {
+    return BigInt(value as string | number | bigint);
+  }
+  if (type === 'bool') {
+    return value === true || value === 'true';
+  }
+  // address, bytes, bytesN, string — forward as-is
+  return value;
+}
+
+/**
+ * Build calldata from a human-readable function signature and its args.
+ * The ABI is inferred from the signature, so no ABI lookup is required.
+ */
+export function encodeCalldata(
+  fnSignature: string,
+  fnArgs: readonly unknown[] = [],
+): Hex {
+  const normalized = fnSignature.trim();
+  const human = normalized.startsWith('function ')
+    ? normalized
+    : `function ${normalized}`;
+
+  const item = parseAbiItem(human);
+  if (item.type !== 'function') {
+    throw new Error(`Signature is not a function: ${fnSignature}`);
+  }
+  if (fnArgs.length !== item.inputs.length) {
+    throw new Error(
+      `Expected ${item.inputs.length} argument(s) for ${item.name}, received ${fnArgs.length}`,
+    );
+  }
+  const args = item.inputs.map((input, i) => coerceArg(input.type, fnArgs[i]));
+  return encodeFunctionData({
+    abi: [item] as Abi,
+    functionName: item.name,
+    args,
+  });
+}
+
+function extractFunctionName(fnSignature: string): string | undefined {
+  return fnSignature
+    .trim()
+    .replace(/^function\s+/, '')
+    .match(/^(\w+)/)?.[1];
+}
+
+/**
+ * Turn a v1 query into a wallet-ready transaction:
+ * `{ chainId, to, value, data }` plus optional display metadata.
+ */
+export function parseTransaction(query: V1Query): ParsedTransaction {
+  const chainId = parseChainId(query.chainId);
+
+  const to = query.to;
+  if (!to || !isAddress(to)) {
+    throw new Error(`Invalid recipient address: ${to}`);
+  }
+
+  const value = parseTxValue(query.value);
+
+  if (query.fnSignature) {
+    const fnArgs = query.fnArgs ?? [];
+    return {
+      chainId,
+      to,
+      value,
+      data: encodeCalldata(query.fnSignature, fnArgs),
+      functionName: extractFunctionName(query.fnSignature),
+      args: fnArgs,
+    };
+  }
+
+  if (query.data) {
+    const data = (
+      query.data.startsWith('0x') ? query.data : `0x${query.data}`
+    ) as Hex;
+    return { chainId, to, value, data };
+  }
+
+  return { chainId, to, value, data: '0x' };
+}
+
+/** Parse a Next.js router query object (strings) into a transaction. */
+export function parseRouterQuery(
+  query: Record<string, string | string[] | undefined>,
+): ParsedTransaction {
+  const get = (key: string): string | undefined => {
+    const v = query[key];
+    return Array.isArray(v) ? v[0] : v;
+  };
+
+  let fnArgs: readonly unknown[] | undefined;
+  const rawArgs = get('fnArgs');
+  if (typeof rawArgs === 'string' && rawArgs.length > 0) {
+    fnArgs = JSON.parse(rawArgs);
+  }
+
+  return parseTransaction({
+    chainId: get('chainId') as string,
+    to: get('to') as string,
+    value: get('value'),
+    data: get('data'),
+    fnSignature: get('fnSignature'),
+    fnArgs,
+  });
+}
+
+export type BuildV1UrlInput = {
+  chainId: number | string;
+  to: string;
+  value?: number | string;
+  data?: string;
+  fnSignature?: string;
+  fnArgs?: readonly unknown[];
+};
+
+/** Build a `/v1/decode?...` URL for a transaction. */
+export function buildV1Url(input: BuildV1UrlInput): string {
+  const params = new URLSearchParams();
+  params.set('chainId', String(input.chainId));
+  params.set('to', input.to);
+
+  if (input.value !== undefined && input.value !== '') {
+    params.set('value', String(input.value));
+  }
+
+  if (input.fnSignature) {
+    params.set('fnSignature', input.fnSignature);
+    params.set('fnArgs', JSON.stringify(input.fnArgs ?? []));
+  } else if (input.data) {
+    params.set('data', input.data);
+  }
+
+  return `/v1/decode?${params.toString()}`;
+}


### PR DESCRIPTION
Implements the **API v1** proposed by @ItsNickBarry in #26. Built **additively** so v0 keeps working for existing links and the [Hardhat plugin](https://github.com/solidstate-network/hardhat-txn-dot-xyz). No v0 page or encoding source was modified.

## What v1 is

The whole transaction lives in the URL, wallet-shaped:

| Param | Notes |
|---|---|
| `chainId` | hex (`0x1`) or decimal (`1`) |
| `to` | recipient (no EOA/contract distinction) |
| `value` | wei, optional, defaults to `0` |
| `data` | a pre-encoded hex string, **or** omitted and supplied via `fnSignature` + `fnArgs` |
| `fnSignature` | full signature, e.g. `transfer(address,uint256)` (named params supported) |
| `fnArgs` | JSON-encoded argument array |

The ABI is **inferred from `fnSignature`**, so the Etherscan ABI lookup is not needed on the v1 encode path.

## Approach (per request)

1. **v0 regression tests first** — `type-casting` + real example-URL decoding, locking v0 behavior before any v1 work.
2. **v1 logic via TDD** — pure, fully unit-tested module in `packages/txn-dot-xyz/utils/v1` (`parseChainId`, `parseTxValue`, `encodeCalldata`, `parseTransaction`, `parseRouterQuery`, `buildV1Url`). 21 tests, incl. large-uint precision, named params, `bytes32[]` merkle proofs.
3. **v1 pages** — new `pages/v1/encode.tsx` + `pages/v1/decode.tsx`. v0 pages untouched.
4. **Homepage** now links to `/v1/encode` and ships v1 example URLs, so users no longer generate v0.

`tsconfig` target bumped `es5 → es2020` (BigInt literals / viem / tsgo). Build config only.

## Verification

`npm test` (34 tests), `tsgo --noEmit`, and `next build` all pass. All routes serve 200 locally. Connect a wallet on these to confirm end-to-end (they switch chains + send):

**v1 (new):**
- Transfer DAI: `/v1/decode?chainId=1&to=0x6b175474e89094c44da98b954eedeac495271d0f&fnSignature=transfer(address,uint256)&fnArgs=["0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB","100"]`
- Approve DAI: `/v1/decode?chainId=1&to=0x6b175474e89094c44da98b954eedeac495271d0f&fnSignature=approve(address,uint256)&fnArgs=["0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB","100"]`
- Claim Airdrop (nested `bytes32[]` proof): see the homepage "Claim Airdrop" card.
- Native transfer (no data): `/v1/decode?chainId=1&to=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB&value=1000000000000000000`

**v0 (still works, unchanged):**
- Transfer DAI: `/v0/decode?chainID=1&contractAddress=0x6b175474e89094c44da98b954eedeac495271d0f&fn=transfer&fnParams=0=0xc0DEAF6bD3F0c6574a6a625EF2F22f62A5150EAB,1=100`

## Open question for @ItsNickBarry

I encoded `fnArgs` as a JSON array (preserves string precision for large uints and supports nesting). Happy to switch to repeated `fnArgs=` params or another shape if you prefer for the plugin.

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)