### PR TITLE
Deduplicate chain ids and names into a single source of truth

### DIFF
--- a/apps/next/pages/_app.tsx
+++ b/apps/next/pages/_app.tsx
@@ -14,17 +14,9 @@ import styled from 'styled-components';
 import { SEO } from '../src/frontend/components/SEO';
 import { useGtag } from '../src/frontend/utils/analytics/gtag';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { http } from 'viem';
-import {
-  arbitrum,
-  base,
-  bsc,
-  gnosis,
-  mainnet,
-  optimism,
-  polygon,
-} from 'viem/chains';
+import { http, type Transport } from 'viem';
 import { WagmiProvider } from 'wagmi';
+import { supportedViemChains } from '../src/chains';
 
 const walletConnectProjectId = z
   .string()
@@ -33,16 +25,10 @@ const walletConnectProjectId = z
 const config = getDefaultConfig({
   appName: 'txn.xyz',
   projectId: walletConnectProjectId,
-  chains: [mainnet, base, polygon, arbitrum, optimism, bsc, gnosis],
-  transports: {
-    [mainnet.id]: http(),
-    [base.id]: http(),
-    [polygon.id]: http(),
-    [arbitrum.id]: http(),
-    [optimism.id]: http(),
-    [bsc.id]: http(),
-    [gnosis.id]: http(),
-  },
+  chains: supportedViemChains,
+  transports: Object.fromEntries(
+    supportedViemChains.map((chain) => [chain.id, http()]),
+  ) as Record<number, Transport>,
 });
 const queryClient = new QueryClient();
 

--- a/apps/next/pages/v0/encode.tsx
+++ b/apps/next/pages/v0/encode.tsx
@@ -11,6 +11,7 @@ import Select from 'react-select';
 import { toast } from 'react-toastify';
 import { EncodeURIComponent } from '../../../../packages/txn-dot-xyz/utils/url-encoding/url-encoding';
 import { Input } from '../../src/frontend/components/Input';
+import { chainOptions } from '../../src/chains';
 
 import styles from '../../styles/Home.module.css';
 
@@ -84,16 +85,8 @@ function encodeParams(
   return `${pathPrefix}?${query}`;
 }
 
-const ethereumOption = { value: 1, label: 'Ethereum' };
-const chainOptions = [
-  ethereumOption,
-  { value: 137, label: 'Polygon' },
-  { value: 10, label: 'Optimism' },
-  { value: 42161, label: 'Arbitrum One' },
-  { value: 100, label: 'Gnosis Chain' },
-  { value: 56, label: 'Binance Smart Chain' },
-  { value: 8453, label: 'Base' },
-];
+// Ethereum is the first supported chain and the default selection.
+const ethereumOption = chainOptions[0];
 
 // @ts-ignore
 const ContractInputs: React.FunctionComponent<{

--- a/apps/next/src/backend/utils/fetch-contract-abi.ts
+++ b/apps/next/src/backend/utils/fetch-contract-abi.ts
@@ -1,5 +1,6 @@
 import type { Abi } from 'viem';
 import * as z from '@zod/mini';
+import { supportedChainIDs } from '../../chains';
 
 type Params = {
   contractAddress: string;
@@ -13,8 +14,6 @@ type Params = {
 // https://docs.etherscan.io/v2-migration
 const ETHERSCAN_API_ROOT = 'https://api.etherscan.io/v2/api';
 const apiKey = z.string().parse(process.env.ETHERSCAN_API_KEY);
-
-const supportedChainIDs = new Set([1, 10, 56, 100, 137, 42161, 8453]);
 
 export const fetchContractABI = async ({
   contractAddress,

--- a/apps/next/src/chains.ts
+++ b/apps/next/src/chains.ts
@@ -1,0 +1,53 @@
+import type { Chain } from 'viem';
+import {
+  arbitrum,
+  base,
+  bsc,
+  gnosis,
+  mainnet,
+  optimism,
+  polygon,
+} from 'viem/chains';
+
+/**
+ * The single source of truth for every chain txn.xyz supports.
+ *
+ * To add a new chain, add one entry here. Everything else derives from this
+ * list: the wallet config in _app.tsx, the chain dropdown on the encode page,
+ * and the backend ABI fetcher's allowlist.
+ *
+ * `label` is the human-facing name shown in the dropdown. We keep it explicit
+ * rather than reading viem's `chain.name` because a few of our preferred names
+ * differ from viem's (e.g. "Binance Smart Chain" vs viem's "BNB Smart Chain").
+ */
+export const supportedChains = [
+  { chain: mainnet, label: 'Ethereum' },
+  { chain: base, label: 'Base' },
+  { chain: polygon, label: 'Polygon' },
+  { chain: arbitrum, label: 'Arbitrum One' },
+  { chain: optimism, label: 'Optimism' },
+  { chain: bsc, label: 'Binance Smart Chain' },
+  { chain: gnosis, label: 'Gnosis Chain' },
+] as const satisfies ReadonlyArray<{ chain: Chain; label: string }>;
+
+/**
+ * The viem chain objects, as the non-empty tuple wagmi/RainbowKit expect.
+ */
+export const supportedViemChains = supportedChains.map(
+  ({ chain }) => chain as Chain,
+) as [Chain, ...Chain[]];
+
+/**
+ * `{ value, label }` options for the encode-page chain dropdown.
+ */
+export const chainOptions = supportedChains.map(({ chain, label }) => ({
+  value: chain.id,
+  label,
+}));
+
+/**
+ * Allowlist of chain IDs the backend will fetch ABIs for.
+ */
+export const supportedChainIDs = new Set<number>(
+  supportedChains.map(({ chain }) => chain.id),
+);


### PR DESCRIPTION
Closes #24

## Problem

Adding a new chain (see #23) required editing three separate places that each listed the full chain set:

- `pages/_app.tsx` — viem imports, wallet `chains`, and `transports`
- `pages/v0/encode.tsx` — the `chainOptions` dropdown (id + label)
- `src/backend/utils/fetch-contract-abi.ts` — the `supportedChainIDs` allowlist

## Change

Introduce `src/chains.ts` as the single source of truth:

```ts
export const supportedChains = [
  { chain: mainnet, label: 'Ethereum' },
  { chain: base,    label: 'Base' },
  // ...
] as const satisfies ReadonlyArray<{ chain: Chain; label: string }>;
```

All three files now import derived values (`supportedViemChains`, `chainOptions`, `supportedChainIDs`) from it. **Adding a chain is now a one-line edit.**

Note: the per-chain explorer API keys/URLs were already consolidated to a single `ETHERSCAN_API_KEY` by the Etherscan V2 migration (#28), so there is no longer per-chain backend config to add.

## Behavior note

The encode-page dropdown order now follows the canonical list (Ethereum, Base, Polygon, Arbitrum One, Optimism, Binance Smart Chain, Gnosis Chain). Same chains, slightly reordered.

## Verification

- `next build` (full type-check + static generation): passing
- Test suite: passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)